### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=SparkFun Electronics
 maintainer=Jim Lindblom <jim@sparkfun.com>
 sentence=Driver library for SparkFun's ESP8266 WiFi Shield.
 paragraph=Simple API to connect to WiFi,  TCP, and other functions made available by the MG2639 Cellular Shield.
+category=Communication
 url=http://github.com/sparkfun/SparkFun_ESP8266_AT_Arduino_Library
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library SparkFun ESP8266 AT Library is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.
