### PR TITLE
Arbitrary HardwareSerials (Serial1, Serial2, ..) for Arduino Mega 2560

### DIFF
--- a/src/SparkFunESP8266Client.cpp
+++ b/src/SparkFunESP8266Client.cpp
@@ -85,30 +85,22 @@ size_t ESP8266Client::write(const uint8_t *buf, size_t size)
 
 int ESP8266Client::available()
 {
-	int available = esp8266.available();
-	if (available == 0)
-	{
-		// Delay for the amount of time it'd take to receive one character
-		delayMicroseconds((1 / esp8266._baud) * 10 * 1E6);
-		// Check again just to be sure:
-		available = esp8266.available();
-	}
-	return esp8266.available();
+	return receiveBuffer.available();
 }
 
 int ESP8266Client::read()
 {
-	return esp8266.read();
+	return receiveBuffer.read();
 }
 
 int ESP8266Client::read(uint8_t *buf, size_t size)
 {
-	if (esp8266.available() < size)
+	if (available() + esp8266.available() < size)
 		return 0;
 	
 	for (int i=0; i<size; i++)
 	{
-		buf[i] = esp8266.read();
+		buf[i] = this->read();
 	}
 	
 	return 1;

--- a/src/SparkFunESP8266Client.cpp
+++ b/src/SparkFunESP8266Client.cpp
@@ -131,7 +131,7 @@ uint8_t ESP8266Client::connected()
 		return 0;
 	else if (available() > 0)
 		return 1;
-	else if (status() == ESP8266_STATUS_CONNECTED)
+	else if (esp8266._status.stat == ESP8266_STATUS_CONNECTED)
 		return 1;
 	
 	return 0;

--- a/src/SparkFunESP8266Client.h
+++ b/src/SparkFunESP8266Client.h
@@ -26,6 +26,9 @@ Distributed as-is; no warranty is given.
 #include <IPAddress.h>
 #include "Client.h"
 #include "SparkFunESP8266WiFi.h"
+#include "SparkFunESP8266ClientReadBuffer.h"
+
+#define ESP8266_CLIENT_MAX_BUFFER_SIZE 256
 
 class ESP8266Client : public Client {
 	
@@ -58,10 +61,11 @@ public:
 	using Print::write;
 
 private:
+	ESP8266ClientReadBuffer receiveBuffer;
 	static uint16_t _srcport;
 	uint16_t  _socket;
 	bool ipMuxEn;
-	
+
 
 	uint8_t getFirstSocket();
 };

--- a/src/SparkFunESP8266ClientReadBuffer.cpp
+++ b/src/SparkFunESP8266ClientReadBuffer.cpp
@@ -16,7 +16,7 @@ int ESP8266ClientReadBuffer::available()
 		// Check again just to be sure:
 		available = esp8266.available();
 	}
-	return esp8266.available();
+	return available;
 }
 
 int ESP8266ClientReadBuffer::read()

--- a/src/SparkFunESP8266ClientReadBuffer.cpp
+++ b/src/SparkFunESP8266ClientReadBuffer.cpp
@@ -1,0 +1,88 @@
+#include "SparkFunESP8266ClientReadBuffer.h"
+#include "SparkFunESP8266WiFi.h"
+
+
+
+int ESP8266ClientReadBuffer::available()
+{
+	if (receiveBufferSize > 0)//client has already buffered some payload
+		return receiveBufferSize;
+
+	int available = esp8266.available();
+	if (available == 0)
+	{
+		// Delay for the amount of time it'd take to receive one character
+		delayMicroseconds((1 / esp8266._baud) * 10 * 1E6);
+		// Check again just to be sure:
+		available = esp8266.available();
+	}
+	return esp8266.available();
+}
+
+int ESP8266ClientReadBuffer::read()
+{
+	this->fillReceiveBuffer();//append to buffer BEFORE we read, so that chances are higher to detect AT commands
+
+	//read from buffer
+	if (receiveBufferSize > 0) {
+		uint8_t ret = receiveBuffer[0];
+		this->truncateReceiveBufferHead(0, 1);
+		return ret;
+	}
+
+	return -1;
+}
+
+void ESP8266ClientReadBuffer::truncateReceiveBufferHead(uint8_t startingOffset, uint8_t truncateLength) {
+	for (uint8_t i = startingOffset; i < receiveBufferSize - truncateLength; i++)//shift buffer content; todo: better implementation
+		receiveBuffer[i] = receiveBuffer[i + truncateLength];
+	receiveBufferSize -= truncateLength;
+}
+
+void ESP8266ClientReadBuffer::fillReceiveBuffer() {
+	//fill the receive buffer as much as possible from esp8266.read()
+
+	for (uint8_t attemps = 0; attemps < 5; attemps++) {//often 1st available() call does not yield all bytes => outer while
+		while (uint8_t availableBytes = esp8266.available() > 0) {
+			for (; availableBytes > 0 && receiveBufferSize < ESP8266_CLIENT_MAX_BUFFER_SIZE; availableBytes--) {
+				receiveBuffer[receiveBufferSize++] = esp8266.read();
+			}
+			delay(10);
+		}
+		delay(10);
+	}
+
+
+	Serial.println("");
+	this->cleanReceiveBufferFromAT();
+	Serial.print("\r\n -- CLEAN -- Filled receive buffer: ");
+	for (int i = 0; i < receiveBufferSize; i++) {
+		if ((char)receiveBuffer[i] != 0)
+			Serial.print((char)receiveBuffer[i]);
+		else
+			Serial.print("NULL");
+		Serial.print("[");
+		Serial.print(receiveBuffer[i], HEX);
+		Serial.print("] ");
+	}
+	Serial.println("");
+}
+
+void ESP8266ClientReadBuffer::cleanReceiveBufferFromAT() {
+	//get rid of these esp8266 commands
+	this->cleanReceiveBufferFromAT("\r\n\r\n+IPD", 5);//typical answer looks like \r\n\r\n+IPD,0,4:<payload>
+}
+
+void ESP8266ClientReadBuffer::cleanReceiveBufferFromAT(const char *atCommand, uint8_t additionalSuffixToKill) {
+	uint8_t atLen = strlen(atCommand);
+
+	//uint8_t offset = 0;
+	for (uint8_t offset = 0; offset <= receiveBufferSize - atLen; offset++) {
+		if (0 == memcmp((receiveBuffer + offset), atCommand, atLen)) {
+			//found the at command. KILL IT!
+			this->truncateReceiveBufferHead(offset, atLen + additionalSuffixToKill);
+			break;
+		}
+	}
+}
+

--- a/src/SparkFunESP8266ClientReadBuffer.cpp
+++ b/src/SparkFunESP8266ClientReadBuffer.cpp
@@ -52,20 +52,7 @@ void ESP8266ClientReadBuffer::fillReceiveBuffer() {
 		delay(10);
 	}
 
-
-	Serial.println("");
 	this->cleanReceiveBufferFromAT();
-	Serial.print("\r\n -- CLEAN -- Filled receive buffer: ");
-	for (int i = 0; i < receiveBufferSize; i++) {
-		if ((char)receiveBuffer[i] != 0)
-			Serial.print((char)receiveBuffer[i]);
-		else
-			Serial.print("NULL");
-		Serial.print("[");
-		Serial.print(receiveBuffer[i], HEX);
-		Serial.print("] ");
-	}
-	Serial.println("");
 }
 
 void ESP8266ClientReadBuffer::cleanReceiveBufferFromAT() {

--- a/src/SparkFunESP8266ClientReadBuffer.h
+++ b/src/SparkFunESP8266ClientReadBuffer.h
@@ -1,0 +1,22 @@
+#ifndef _SPARKFUNESP8266CLIENTBUFFER_H_
+#define _SPARKFUNESP8266CLIENTBUFFER_H_
+#include <Arduino.h>
+
+#define ESP8266_CLIENT_MAX_BUFFER_SIZE 256
+
+class ESP8266ClientReadBuffer {
+public:
+	int available();
+	int read();
+
+protected:
+	char receiveBufferSize = 0;
+	uint8_t receiveBuffer[ESP8266_CLIENT_MAX_BUFFER_SIZE];
+
+	void fillReceiveBuffer();
+	void truncateReceiveBufferHead(uint8_t startingOffset, uint8_t truncateLength);
+	void cleanReceiveBufferFromAT();
+	void cleanReceiveBufferFromAT(const char *atCommand, uint8_t additionalSuffixToKill);
+};
+
+#endif

--- a/src/SparkFunESP8266WiFi.cpp
+++ b/src/SparkFunESP8266WiFi.cpp
@@ -8,9 +8,9 @@ http://github.com/sparkfun/SparkFun_ESP8266_AT_Arduino_Library
 !!! Description Here !!!
 
 Development environment specifics:
-	IDE: Arduino 1.6.5
-	Hardware Platform: Arduino Uno
-	ESP8266 WiFi Shield Version: 1.0
+IDE: Arduino 1.6.5
+Hardware Platform: Arduino Uno
+ESP8266 WiFi Shield Version: 1.0
 
 This code is beerware; if you see me (or any other SparkFun employee) at the
 local, and you've found our code helpful, please buy us a round!
@@ -18,7 +18,7 @@ local, and you've found our code helpful, please buy us a round!
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
-#include <SparkFunESP8266WiFi.h>
+#include "SparkFunESP8266WiFi.h"
 #include <Arduino.h>
 #include "util/ESP8266_AT.h"
 #include "SparkFunESP8266Client.h"
@@ -32,17 +32,17 @@ Distributed as-is; no warranty is given.
 char esp8266RxBuffer[ESP8266_RX_BUFFER_LEN];
 unsigned int bufferHead; // Holds position of latest byte placed in buffer.
 
-////////////////////
-// Initialization //
-////////////////////
+						 ////////////////////
+						 // Initialization //
+						 ////////////////////
 
 ESP8266Class::ESP8266Class()
 {
-	for (int i=0; i<ESP8266_MAX_SOCK_NUM; i++)
+	for (int i = 0; i<ESP8266_MAX_SOCK_NUM; i++)
 		_state[i] = AVAILABLE;
 }
 
-bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort)
+bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort, HardwareSerial *hwSerial)
 {
 	_baud = baudRate;
 	if (serialPort == ESP8266_SOFTWARE_SERIAL)
@@ -52,10 +52,17 @@ bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort)
 	}
 	else if (serialPort == ESP8266_HARDWARE_SERIAL)
 	{
-		Serial.begin(baudRate);
-		_serial = &Serial;
+		if (hwSerial == 0) {
+			Serial.begin(baudRate);
+			_serial = &Serial;
+		}
+		else {
+			hwSerial->begin(baudRate);
+			_serial = hwSerial;
+		}
 	}
-	
+
+
 	if (test())
 	{
 		//if (!setTransferMode(0))
@@ -68,7 +75,7 @@ bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort)
 #endif
 		return true;
 	}
-	
+
 	return false;
 }
 
@@ -82,17 +89,17 @@ bool ESP8266Class::test()
 
 	if (readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT) > 0)
 		return true;
-	
+
 	return false;
 }
 
 bool ESP8266Class::reset()
 {
 	sendCommand(ESP8266_RESET); // Send AT+RST
-	
+
 	if (readForResponse(RESPONSE_READY, COMMAND_RESET_TIMEOUT) > 0)
 		return true;
-	
+
 	return false;
 }
 
@@ -102,10 +109,10 @@ bool ESP8266Class::echo(bool enable)
 		sendCommand(ESP8266_ECHO_ENABLE);
 	else
 		sendCommand(ESP8266_ECHO_DISABLE);
-	
+
 	if (readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT) > 0)
 		return true;
-	
+
 	return false;
 }
 
@@ -115,28 +122,28 @@ bool ESP8266Class::setBaud(unsigned long baud)
 	memset(parameters, 0, 16);
 	// Constrain parameters:
 	baud = constrain(baud, 110, 115200);
-	
+
 	// Put parameters into string
 	sprintf(parameters, "%d,8,1,0,0", baud);
-	
+
 	// Send AT+UART=baud,databits,stopbits,parity,flowcontrol
 	sendCommand(ESP8266_UART, ESP8266_CMD_SETUP, parameters);
-	
+
 	if (readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT) > 0)
 		return true;
-	
+
 	return false;
 }
 
 int16_t ESP8266Class::getVersion(char * ATversion, char * SDKversion, char * compileTime)
 {
 	sendCommand(ESP8266_VERSION); // Send AT+GMR
-	// Example Response: AT version:0.30.0.0(Jul  3 2015 19:35:49)\r\n (43 chars)
-	//                   SDK version:1.2.0\r\n (19 chars)
-	//                   compile time:Jul  7 2015 18:34:26\r\n (36 chars)
-	//                   OK\r\n
-	// (~101 characters)
-	// Look for "OK":
+								  // Example Response: AT version:0.30.0.0(Jul  3 2015 19:35:49)\r\n (43 chars)
+								  //                   SDK version:1.2.0\r\n (19 chars)
+								  //                   compile time:Jul  7 2015 18:34:26\r\n (36 chars)
+								  //                   OK\r\n
+								  // (~101 characters)
+								  // Look for "OK":
 	int16_t rsp = (readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT) > 0);
 	if (rsp > 0)
 	{
@@ -147,25 +154,25 @@ int16_t ESP8266Class::getVersion(char * ATversion, char * SDKversion, char * com
 		p += strlen("AT version:");
 		q = strchr(p, '\r'); // Look for \r
 		if (q == NULL) return ESP8266_RSP_UNKNOWN;
-		strncpy(ATversion, p, q-p);
-		
+		strncpy(ATversion, p, q - p);
+
 		// Look for "SDK version:" in the rxBuffer
 		p = strstr(esp8266RxBuffer, "SDK version:");
 		if (p == NULL) return ESP8266_RSP_UNKNOWN;
 		p += strlen("SDK version:");
 		q = strchr(p, '\r'); // Look for \r
 		if (q == NULL) return ESP8266_RSP_UNKNOWN;
-		strncpy(SDKversion, p, q-p);
-		
+		strncpy(SDKversion, p, q - p);
+
 		// Look for "compile time:" in the rxBuffer
 		p = strstr(esp8266RxBuffer, "compile time:");
 		if (p == NULL) return ESP8266_RSP_UNKNOWN;
 		p += strlen("compile time:");
 		q = strchr(p, '\r'); // Look for \r
 		if (q == NULL) return ESP8266_RSP_UNKNOWN;
-		strncpy(compileTime, p, q-p);
+		strncpy(compileTime, p, q - p);
 	}
-	
+
 	return rsp;
 }
 
@@ -181,7 +188,7 @@ int16_t ESP8266Class::getVersion(char * ATversion, char * SDKversion, char * com
 int16_t ESP8266Class::getMode()
 {
 	sendCommand(ESP8266_WIFI_MODE, ESP8266_CMD_QUERY);
-	
+
 	// Example response: \r\nAT+CWMODE_CUR?\r+CWMODE_CUR:2\r\n\r\nOK\r\n
 	// Look for the OK:
 	int16_t rsp = readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
@@ -191,14 +198,14 @@ int16_t ESP8266Class::getMode()
 		char * p = strchr(esp8266RxBuffer, ':');
 		if (p != NULL)
 		{
-			char mode = *(p+1);
+			char mode = *(p + 1);
 			if ((mode >= '1') && (mode <= '3'))
 				return (mode - 48); // Convert ASCII to decimal
 		}
-		
+
 		return ESP8266_RSP_UNKNOWN;
 	}
-	
+
 	return rsp;
 }
 
@@ -209,10 +216,10 @@ int16_t ESP8266Class::getMode()
 //    - Fail: <0 (esp8266_cmd_rsp)
 int16_t ESP8266Class::setMode(esp8266_wifi_mode mode)
 {
-	char modeChar[2] = {0, 0};
+	char modeChar[2] = { 0, 0 };
 	sprintf(modeChar, "%d", mode);
 	sendCommand(ESP8266_WIFI_MODE, ESP8266_CMD_SETUP, modeChar);
-	
+
 	return readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
 }
 
@@ -241,14 +248,14 @@ int16_t ESP8266Class::connect(const char * ssid, const char * pwd)
 		_serial->print("\"");
 	}
 	_serial->print("\r\n");
-	
+
 	return readForResponses(RESPONSE_OK, RESPONSE_FAIL, WIFI_CONNECT_TIMEOUT);
 }
 
 int16_t ESP8266Class::getAP(char * ssid)
 {
 	sendCommand(ESP8266_CONNECT_AP, ESP8266_CMD_QUERY); // Send "AT+CWJAP?"
-	
+
 	int16_t rsp = readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
 	// Example Responses: No AP\r\n\r\nOK\r\n
 	// - or -
@@ -258,7 +265,7 @@ int16_t ESP8266Class::getAP(char * ssid)
 		// Look for "No AP"
 		if (strstr(esp8266RxBuffer, "No AP") != NULL)
 			return 0;
-		
+
 		// Look for "+CWJAP"
 		char * p = strstr(esp8266RxBuffer, ESP8266_CONNECT_AP);
 		if (p != NULL)
@@ -266,19 +273,19 @@ int16_t ESP8266Class::getAP(char * ssid)
 			p += strlen(ESP8266_CONNECT_AP) + 2;
 			char * q = strchr(p, '"');
 			if (q == NULL) return ESP8266_RSP_UNKNOWN;
-			strncpy(ssid, p, q-p); // Copy string to temp char array:
+			strncpy(ssid, p, q - p); // Copy string to temp char array:
 			return 1;
 		}
 	}
-	
+
 	return rsp;
 }
 
 int16_t ESP8266Class::disconnect()
 {
 	sendCommand(ESP8266_DISCONNECT); // Send AT+CWQAP
-	// Example response: \r\n\r\nOK\r\nWIFI DISCONNECT\r\n
-	// "WIFI DISCONNECT" comes up to 500ms _after_ OK. 
+									 // Example response: \r\n\r\nOK\r\nWIFI DISCONNECT\r\n
+									 // "WIFI DISCONNECT" comes up to 500ms _after_ OK. 
 	int16_t rsp = readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
 	if (rsp > 0)
 	{
@@ -287,7 +294,7 @@ int16_t ESP8266Class::disconnect()
 			return rsp;
 		return 1;
 	}
-	
+
 	return rsp;
 }
 
@@ -319,30 +326,30 @@ int16_t ESP8266Class::status()
 int16_t ESP8266Class::updateStatus()
 {
 	sendCommand(ESP8266_TCP_STATUS); // Send AT+CIPSTATUS\r\n
-	// Example response: (connected as client)
-	// STATUS:3\r\n
-	// +CIPSTATUS:0,"TCP","93.184.216.34",80,0\r\n\r\nOK\r\n 
-	// - or - (clients connected to ESP8266 server)
-	// STATUS:3\r\n
-	// +CIPSTATUS:0,"TCP","192.168.0.100",54723,1\r\n
-	// +CIPSTATUS:1,"TCP","192.168.0.101",54724,1\r\n\r\nOK\r\n 
+									 // Example response: (connected as client)
+									 // STATUS:3\r\n
+									 // +CIPSTATUS:0,"TCP","93.184.216.34",80,0\r\n\r\nOK\r\n 
+									 // - or - (clients connected to ESP8266 server)
+									 // STATUS:3\r\n
+									 // +CIPSTATUS:0,"TCP","192.168.0.100",54723,1\r\n
+									 // +CIPSTATUS:1,"TCP","192.168.0.101",54724,1\r\n\r\nOK\r\n 
 	int16_t rsp = readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
 	if (rsp > 0)
 	{
 		char * p = searchBuffer("STATUS:");
 		if (p == NULL)
 			return ESP8266_RSP_UNKNOWN;
-		
+
 		p += strlen("STATUS:");
 		_status.stat = (esp8266_connect_status)(*p - 48);
-		
-		for (int i=0; i<ESP8266_MAX_SOCK_NUM; i++)
+
+		for (int i = 0; i<ESP8266_MAX_SOCK_NUM; i++)
 		{
 			p = strstr(p, "+CIPSTATUS:");
 			if (p == NULL)
 			{
 				// Didn't find any IPSTATUS'. Set linkID to 255.
-				for (int j=i; j<ESP8266_MAX_SOCK_NUM; j++)
+				for (int j = i; j<ESP8266_MAX_SOCK_NUM; j++)
 					_status.ipstatus[j].linkID = 255;
 				return rsp;
 			}
@@ -354,7 +361,7 @@ int16_t ESP8266Class::updateStatus()
 				if (linkId >= ESP8266_MAX_SOCK_NUM)
 					return rsp;
 				_status.ipstatus[linkId].linkID = linkId;
-				
+
 				// Find type (p pointing at linkID):
 				p += 3; // Move p to either "T" or "U"
 				if (*p == 'T')
@@ -363,22 +370,22 @@ int16_t ESP8266Class::updateStatus()
 					_status.ipstatus[linkId].type = ESP8266_UDP;
 				else
 					_status.ipstatus[linkId].type = ESP8266_TYPE_UNDEFINED;
-				
+
 				// Find remoteIP (p pointing at first letter or type):
 				p += 6; // Move p to first digit of first octet.
 				for (uint8_t j = 0; j < 4; j++)
 				{
 					char tempOctet[4];
 					memset(tempOctet, 0, 4); // Clear tempOctet
-					
+
 					size_t octetLength = strspn(p, "0123456789"); // Find length of numerical string:
-					
+
 					strncpy(tempOctet, p, octetLength); // Copy string to temp char array:
 					_status.ipstatus[linkId].remoteIP[j] = atoi(tempOctet); // Move the temp char into IP Address octet
-					
+
 					p += (octetLength + 1); // Increment p to next octet
 				}
-				
+
 				// Find port (p pointing at ',' between IP and port:
 				p += 1; // Move p to first digit of port
 				char tempPort[6];
@@ -387,7 +394,7 @@ int16_t ESP8266Class::updateStatus()
 				strncpy(tempPort, p, portLen);
 				_status.ipstatus[linkId].port = atoi(tempPort);
 				p += portLen + 1;
-				
+
 				// Find tetype (p pointing at tetype)
 				if (*p == '0')
 					_status.ipstatus[linkId].tetype = ESP8266_CLIENT;
@@ -396,7 +403,7 @@ int16_t ESP8266Class::updateStatus()
 			}
 		}
 	}
-	
+
 	return rsp;
 }
 
@@ -408,11 +415,11 @@ int16_t ESP8266Class::updateStatus()
 IPAddress ESP8266Class::localIP()
 {
 	sendCommand(ESP8266_GET_LOCAL_IP); // Send AT+CIFSR\r\n
-	// Example Response: +CIFSR:STAIP,"192.168.0.114"\r\n
-	//                   +CIFSR:STAMAC,"18:fe:34:9d:b7:d9"\r\n
-	//                   \r\n
-	//                   OK\r\n
-	// Look for the OK:
+									   // Example Response: +CIFSR:STAIP,"192.168.0.114"\r\n
+									   //                   +CIFSR:STAMAC,"18:fe:34:9d:b7:d9"\r\n
+									   //                   \r\n
+									   //                   OK\r\n
+									   // Look for the OK:
 	int16_t rsp = readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
 	if (rsp > 0)
 	{
@@ -421,27 +428,27 @@ IPAddress ESP8266Class::localIP()
 		if (p != NULL)
 		{
 			IPAddress returnIP;
-			
+
 			p += 7; // Move p seven places. (skip STAIP,")
 			for (uint8_t i = 0; i < 4; i++)
 			{
 				char tempOctet[4];
 				memset(tempOctet, 0, 4); // Clear tempOctet
-				
+
 				size_t octetLength = strspn(p, "0123456789"); // Find length of numerical string:
 				if (octetLength >= 4) // If it's too big, return an error
 					return ESP8266_RSP_UNKNOWN;
-				
+
 				strncpy(tempOctet, p, octetLength); // Copy string to temp char array:
 				returnIP[i] = atoi(tempOctet); // Move the temp char into IP Address octet
-				
+
 				p += (octetLength + 1); // Increment p to next octet
 			}
-			
+
 			return returnIP;
 		}
 	}
-	
+
 	return rsp;
 }
 
@@ -496,7 +503,7 @@ int16_t ESP8266Class::tcpConnect(uint8_t linkID, const char * destination, uint1
 	// Example bad: DNS Fail\r\n\r\nERROR\r\n
 	// Example meh: ALREADY CONNECTED\r\n\r\nERROR\r\n
 	int16_t rsp = readForResponses(RESPONSE_OK, RESPONSE_ERROR, CLIENT_CONNECT_TIMEOUT);
-	
+
 	if (rsp < 0)
 	{
 		// We may see "ERROR", but be "ALREADY CONNECTED".
@@ -513,24 +520,49 @@ int16_t ESP8266Class::tcpConnect(uint8_t linkID, const char * destination, uint1
 
 int16_t ESP8266Class::tcpSend(uint8_t linkID, const uint8_t *buf, size_t size)
 {
+
 	if (size > 2048)
 		return ESP8266_CMD_BAD;
 	char params[8];
 	sprintf(params, "%d,%d", linkID, size);
+	Serial.print("Sending via tcp - params: "); Serial.print(linkID); Serial.print(", "); Serial.println(size);
 	sendCommand(ESP8266_TCP_SEND, ESP8266_CMD_SETUP, params);
-	
+
 	int16_t rsp = readForResponses(RESPONSE_OK, RESPONSE_ERROR, COMMAND_RESPONSE_TIMEOUT);
 	//if (rsp > 0)
 	if (rsp != ESP8266_RSP_FAIL)
 	{
-		print((const char *)buf);
+		Serial.println("nearly there..");
+		Serial.print("size: ");
+		Serial.println(size);
+
+		Serial.print("payload: ");
+		char deleteme[2];
+		deleteme[1] = 0x00;
+		for (int i = 0; i < size; i++) {
+			deleteme[0] = buf[i];
+			Serial.print(deleteme);
+		}
+		Serial.println("");
+
+		//print((const char *)buf);
+		for (size_t i = 0; i < size; i++)
+			write(buf[i]);
 		
 		rsp = readForResponse("SEND OK", COMMAND_RESPONSE_TIMEOUT);
-		
-		if (rsp > 0)
+
+		if (rsp > 0) {
+			Serial.println("Send successful :)");
 			return size;
+		}
+		else {
+			Serial.println("Send not successful :(");
+		}
 	}
-	
+	else {
+		Serial.println("cannot send. :(");
+	}
+
 	return rsp;
 }
 
@@ -539,7 +571,7 @@ int16_t ESP8266Class::close(uint8_t linkID)
 	char params[2];
 	sprintf(params, "%d", linkID);
 	sendCommand(ESP8266_TCP_CLOSE, ESP8266_CMD_SETUP, params);
-	
+
 	// Eh, client virtual function doesn't have a return value.
 	// We'll wait for the OK or timeout anyway.
 	return readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
@@ -547,19 +579,19 @@ int16_t ESP8266Class::close(uint8_t linkID)
 
 int16_t ESP8266Class::setTransferMode(uint8_t mode)
 {
-	char params[2] = {0, 0};
+	char params[2] = { 0, 0 };
 	params[0] = (mode > 0) ? '1' : '0';
 	sendCommand(ESP8266_TRANSMISSION_MODE, ESP8266_CMD_SETUP, params);
-	
+
 	return readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
 }
 
 int16_t ESP8266Class::setMux(uint8_t mux)
 {
-	char params[2] = {0, 0};
+	char params[2] = { 0, 0 };
 	params[0] = (mux > 0) ? '1' : '0';
 	sendCommand(ESP8266_TCP_MULTIPLE, ESP8266_CMD_SETUP, params);
-	
+
 	return readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
 }
 
@@ -569,8 +601,8 @@ int16_t ESP8266Class::configureTCPServer(uint16_t port, uint8_t create)
 	if (create > 1) create = 1;
 	sprintf(params, "%d,%d", create, port);
 	sendCommand(ESP8266_SERVER_CONFIG, ESP8266_CMD_SETUP, params);
-	
-	return readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);	
+
+	return readForResponse(RESPONSE_OK, COMMAND_RESPONSE_TIMEOUT);
 }
 
 int16_t ESP8266Class::ping(IPAddress ip)
@@ -585,7 +617,7 @@ int16_t ESP8266Class::ping(char * server)
 	char params[strlen(server) + 3];
 	sprintf(params, "\"%s\"", server);
 	// Send AT+Ping=<server>
-	sendCommand(ESP8266_PING, ESP8266_CMD_SETUP, params); 
+	sendCommand(ESP8266_PING, ESP8266_CMD_SETUP, params);
 	// Example responses:
 	//  * Good response: +12\r\n\r\nOK\r\n
 	//  * Timeout response: +timeout\r\n\r\nERROR\r\n
@@ -607,7 +639,7 @@ int16_t ESP8266Class::ping(char * server)
 		if (searchBuffer("timeout") != NULL)
 			return 0;
 	}
-	
+
 	return rsp;
 }
 
@@ -617,40 +649,40 @@ int16_t ESP8266Class::ping(char * server)
 int16_t ESP8266Class::pinMode(uint8_t pin, uint8_t mode)
 {
 	char params[5];
-	
+
 	char modeC = 'i'; // Default mode to input
-	if (mode == OUTPUT) 
+	if (mode == OUTPUT)
 		modeC = 'o'; // o = OUTPUT
-	else if (mode == INPUT_PULLUP) 
+	else if (mode == INPUT_PULLUP)
 		modeC = 'p'; // p = INPUT_PULLUP
-	
+
 	sprintf(params, "%d,%c", pin, modeC);
 	sendCommand(ESP8266_PINMODE, ESP8266_CMD_SETUP, params);
-	
+
 	return readForResponses(RESPONSE_OK, RESPONSE_ERROR, COMMAND_RESPONSE_TIMEOUT);
 }
 
 int16_t ESP8266Class::digitalWrite(uint8_t pin, uint8_t state)
 {
 	char params[5];
-	
+
 	char stateC = 'l'; // Default state to LOW
-	if (state == HIGH) 
+	if (state == HIGH)
 		stateC = 'h'; // h = HIGH
-	
+
 	sprintf(params, "%d,%c", pin, stateC);
 	sendCommand(ESP8266_PINWRITE, ESP8266_CMD_SETUP, params);
-	
+
 	return readForResponses(RESPONSE_OK, RESPONSE_ERROR, COMMAND_RESPONSE_TIMEOUT);
 }
 
 int8_t ESP8266Class::digitalRead(uint8_t pin)
 {
 	char params[3];
-	
+
 	sprintf(params, "%d", pin);
 	sendCommand(ESP8266_PINREAD, ESP8266_CMD_SETUP, params); // Send AT+PINREAD=n\r\n
-	// Example response: 1\r\n\r\nOK\r\n
+															 // Example response: 1\r\n\r\nOK\r\n
 	if (readForResponses(RESPONSE_OK, RESPONSE_ERROR, COMMAND_RESPONSE_TIMEOUT) > 0)
 	{
 		if (strchr(esp8266RxBuffer, '0') != NULL)
@@ -658,7 +690,7 @@ int8_t ESP8266Class::digitalRead(uint8_t pin)
 		else if (strchr(esp8266RxBuffer, '1') != NULL)
 			return HIGH;
 	}
-	
+
 	return -1;
 }
 
@@ -704,7 +736,7 @@ void ESP8266Class::sendCommand(const char * cmd, enum esp8266_command_type type,
 	else if (type == ESP8266_CMD_SETUP)
 	{
 		_serial->print("=");
-		_serial->print(params);		
+		_serial->print(params);
 	}
 	_serial->print("\r\n");
 }
@@ -713,7 +745,7 @@ int16_t ESP8266Class::readForResponse(const char * rsp, unsigned int timeout)
 {
 	unsigned long timeIn = millis();	// Timestamp coming into function
 	unsigned int received = 0; // received keeps track of number of chars read
-	
+
 	clearBuffer();	// Clear the class receive buffer (esp8266RxBuffer)
 	while (timeIn + timeout > millis()) // While we haven't timed out
 	{
@@ -724,7 +756,7 @@ int16_t ESP8266Class::readForResponse(const char * rsp, unsigned int timeout)
 				return received;	// Return how number of chars read
 		}
 	}
-	
+
 	if (received > 0) // If we received any characters
 		return ESP8266_RSP_UNKNOWN; // Return unkown response error code
 	else // If we haven't received any characters
@@ -735,7 +767,7 @@ int16_t ESP8266Class::readForResponses(const char * pass, const char * fail, uns
 {
 	unsigned long timeIn = millis();	// Timestamp coming into function
 	unsigned int received = 0; // received keeps track of number of chars read
-	
+
 	clearBuffer();	// Clear the class receive buffer (esp8266RxBuffer)
 	while (timeIn + timeout > millis()) // While we haven't timed out
 	{
@@ -748,7 +780,7 @@ int16_t ESP8266Class::readForResponses(const char * pass, const char * fail, uns
 				return ESP8266_RSP_FAIL;
 		}
 	}
-	
+
 	if (received > 0) // If we received any characters
 		return ESP8266_RSP_UNKNOWN; // Return unkown response error code
 	else // If we haven't received any characters
@@ -762,18 +794,18 @@ void ESP8266Class::clearBuffer()
 {
 	memset(esp8266RxBuffer, '\0', ESP8266_RX_BUFFER_LEN);
 	bufferHead = 0;
-}	
+}
 
 unsigned int ESP8266Class::readByteToBuffer()
 {
 	// Read the data in
 	char c = _serial->read();
-	
+
 	// Store the data in the buffer
 	esp8266RxBuffer[bufferHead] = c;
 	//! TODO: Don't care if we overflow. Should we? Set a flag or something?
 	bufferHead = (bufferHead + 1) % ESP8266_RX_BUFFER_LEN;
-	
+
 	return 1;
 }
 
@@ -788,9 +820,9 @@ char * ESP8266Class::searchBuffer(const char * test)
 		// If the buffer is full, we need to search from the end of the 
 		// buffer back to the beginning.
 		int testLen = strlen(test);
-		for (int i=0; i<ESP8266_RX_BUFFER_LEN; i++)
+		for (int i = 0; i<ESP8266_RX_BUFFER_LEN; i++)
 		{
-			
+
 		}
 	}
 }

--- a/src/SparkFunESP8266WiFi.cpp
+++ b/src/SparkFunESP8266WiFi.cpp
@@ -312,9 +312,9 @@ int16_t ESP8266Class::status()
 		{
 		case ESP8266_STATUS_GOTIP: // 3
 		case ESP8266_STATUS_DISCONNECTED: // 4 - "Client" disconnected, not wifi
+		case ESP8266_STATUS_CONNECTED: // Connected, but haven't gotten an IP
 			return 1;
 			break;
-		case ESP8266_STATUS_CONNECTED: // Connected, but haven't gotten an IP
 		case ESP8266_STATUS_NOWIFI: // No WiFi configured
 			return 0;
 			break;

--- a/src/SparkFunESP8266WiFi.cpp
+++ b/src/SparkFunESP8266WiFi.cpp
@@ -525,42 +525,27 @@ int16_t ESP8266Class::tcpSend(uint8_t linkID, const uint8_t *buf, size_t size)
 		return ESP8266_CMD_BAD;
 	char params[8];
 	sprintf(params, "%d,%d", linkID, size);
-	Serial.print("Sending via tcp - params: "); Serial.print(linkID); Serial.print(", "); Serial.println(size);
 	sendCommand(ESP8266_TCP_SEND, ESP8266_CMD_SETUP, params);
 
 	int16_t rsp = readForResponses(RESPONSE_OK, RESPONSE_ERROR, COMMAND_RESPONSE_TIMEOUT);
 	//if (rsp > 0)
 	if (rsp != ESP8266_RSP_FAIL)
 	{
-		Serial.println("nearly there..");
-		Serial.print("size: ");
-		Serial.println(size);
-
-		Serial.print("payload: ");
-		char deleteme[2];
-		deleteme[1] = 0x00;
-		for (int i = 0; i < size; i++) {
-			deleteme[0] = buf[i];
-			Serial.print(deleteme);
-		}
-		Serial.println("");
-
-		//print((const char *)buf);
 		for (size_t i = 0; i < size; i++)
 			write(buf[i]);
 		
 		rsp = readForResponse("SEND OK", COMMAND_RESPONSE_TIMEOUT);
 
 		if (rsp > 0) {
-			Serial.println("Send successful :)");
+			//Serial.println("Send successful :)");
 			return size;
 		}
 		else {
-			Serial.println("Send not successful :(");
+			//Serial.println("Send not successful :(");
 		}
 	}
 	else {
-		Serial.println("cannot send. :(");
+		//Serial.println("cannot send. :(");
 	}
 
 	return rsp;

--- a/src/SparkFunESP8266WiFi.cpp
+++ b/src/SparkFunESP8266WiFi.cpp
@@ -42,7 +42,7 @@ ESP8266Class::ESP8266Class()
 		_state[i] = AVAILABLE;
 }
 
-bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort, HardwareSerial *hwSerial = 0)
+bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort, HardwareSerial *hwSerial)
 {
 	_baud = baudRate;
 	if (serialPort == ESP8266_SOFTWARE_SERIAL)

--- a/src/SparkFunESP8266WiFi.cpp
+++ b/src/SparkFunESP8266WiFi.cpp
@@ -42,7 +42,7 @@ ESP8266Class::ESP8266Class()
 		_state[i] = AVAILABLE;
 }
 
-bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort)
+bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort, HardwareSerial *hwSerial = 0)
 {
 	_baud = baudRate;
 	if (serialPort == ESP8266_SOFTWARE_SERIAL)
@@ -52,8 +52,14 @@ bool ESP8266Class::begin(unsigned long baudRate, esp8266_serial_port serialPort)
 	}
 	else if (serialPort == ESP8266_HARDWARE_SERIAL)
 	{
-		Serial.begin(baudRate);
-		_serial = &Serial;
+		if (hwSerial == 0) {
+			Serial.begin(baudRate);
+			_serial = &Serial;
+		}
+		else {
+			hwSerial->begin(baudRate);
+			_serial = hwSerial;
+		}
 	}
 	
 	if (test())

--- a/src/SparkFunESP8266WiFi.h
+++ b/src/SparkFunESP8266WiFi.h
@@ -123,8 +123,8 @@ class ESP8266Class : public Stream
 public:
 	ESP8266Class();
 	
-	bool begin(unsigned long baudRate = 9600, esp8266_serial_port serialPort = ESP8266_SOFTWARE_SERIAL);
-	
+	bool begin(unsigned long baudRate = 9600, esp8266_serial_port serialPort = ESP8266_SOFTWARE_SERIAL, HardwareSerial *hwSerial = 0);
+
 	///////////////////////
 	// Basic AT Commands //
 	///////////////////////

--- a/src/SparkFunESP8266WiFi.h
+++ b/src/SparkFunESP8266WiFi.h
@@ -8,9 +8,9 @@ http://github.com/sparkfun/SparkFun_ESP8266_AT_Arduino_Library
 !!! Description Here !!!
 
 Development environment specifics:
-	IDE: Arduino 1.6.5
-	Hardware Platform: Arduino Uno
-	ESP8266 WiFi Shield Version: 1.0
+IDE: Arduino 1.6.5
+Hardware Platform: Arduino Uno
+ESP8266 WiFi Shield Version: 1.0
 
 This code is beerware; if you see me (or any other SparkFun employee) at the
 local, and you've found our code helpful, please buy us a round!
@@ -79,7 +79,7 @@ typedef enum esp8266_connect_status {
 	ESP8266_STATUS_GOTIP = 2,
 	ESP8266_STATUS_CONNECTED = 3,
 	ESP8266_STATUS_DISCONNECTED = 4,
-	ESP8266_STATUS_NOWIFI = 5	
+	ESP8266_STATUS_NOWIFI = 5
 };
 
 typedef enum esp8266_serial_port {
@@ -122,9 +122,9 @@ class ESP8266Class : public Stream
 {
 public:
 	ESP8266Class();
-	
-	bool begin(unsigned long baudRate = 9600, esp8266_serial_port serialPort = ESP8266_SOFTWARE_SERIAL);
-	
+
+	bool begin(unsigned long baudRate = 9600, esp8266_serial_port serialPort = ESP8266_SOFTWARE_SERIAL, HardwareSerial *hwSerial = 0);
+
 	///////////////////////
 	// Basic AT Commands //
 	///////////////////////
@@ -133,7 +133,7 @@ public:
 	int16_t getVersion(char * ATversion, char * SDKversion, char * compileTime);
 	bool echo(bool enable);
 	bool setBaud(unsigned long baud);
-	
+
 	////////////////////
 	// WiFi Functions //
 	////////////////////
@@ -146,7 +146,7 @@ public:
 	int16_t localMAC(char * mac);
 	int16_t disconnect();
 	IPAddress localIP();
-	
+
 	/////////////////////
 	// TCP/IP Commands //
 	/////////////////////
@@ -160,14 +160,14 @@ public:
 	int16_t configureTCPServer(uint16_t port, uint8_t create = 1);
 	int16_t ping(IPAddress ip);
 	int16_t ping(char * server);
-		
+
 	//////////////////////////
 	// Custom GPIO Commands //
 	//////////////////////////
 	int16_t pinMode(uint8_t pin, uint8_t mode);
 	int16_t digitalWrite(uint8_t pin, uint8_t state);
 	int8_t digitalRead(uint8_t pin);
-	
+
 	///////////////////////////////////
 	// Virtual Functions from Stream //
 	///////////////////////////////////
@@ -176,16 +176,17 @@ public:
 	int read();
 	int peek();
 	void flush();
-	
+
 	friend class ESP8266Client;
+	friend class ESP8266ClientReadBuffer;
 	friend class ESP8266Server;
 
-    int16_t _state[ESP8266_MAX_SOCK_NUM];
-	
+	int16_t _state[ESP8266_MAX_SOCK_NUM];
+
 protected:
-    Stream* _serial;
+	Stream* _serial;
 	unsigned long _baud;
-	
+
 private:
 	//////////////////////////
 	// Command Send/Receive //
@@ -193,25 +194,25 @@ private:
 	void sendCommand(const char * cmd, enum esp8266_command_type type = ESP8266_CMD_EXECUTE, const char * params = NULL);
 	int16_t readForResponse(const char * rsp, unsigned int timeout);
 	int16_t readForResponses(const char * pass, const char * fail, unsigned int timeout);
-	
+
 	//////////////////
 	// Buffer Stuff // 
 	//////////////////
 	/// clearBuffer() - Reset buffer pointer, set all values to 0
 	void clearBuffer();
-	
+
 	/// readByteToBuffer() - Read first byte from UART receive buffer
 	/// and store it in rxBuffer.
 	unsigned int readByteToBuffer();
-	
+
 	/// searchBuffer([test]) - Search buffer for string [test]
 	/// Success: Returns pointer to beginning of string
 	/// Fail: returns NULL
 	//! TODO: Fix this function so it searches circularly
 	char * searchBuffer(const char * test);
-	
+
 	esp8266_status _status;
-	
+
 	uint8_t sync();
 };
 


### PR DESCRIPTION
Hi Guys,

The original library allows only "Serial" as a Hardware Serial. As I am working with an ATMega 2560, I rather want to use Serial1 or Serial2.

Notes:
- extended begin() with an optional parameter for HardwareSerial (defaulted to "Serial").
- begin() signature still compatible with previous library versions
- will compile for boards without Serial1,-2,-3

Thanks for the great library!

Regards
Markus
